### PR TITLE
set to use dark mode or local storage

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -15,8 +15,16 @@
 		/>
 
 		<script>
-			// Prevent flash of light theme on load
-			if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+			document.documentElement.classList.add('dark');
+			
+			if (localStorage.getItem('theme') === 'light') 
+			{
+    			document.documentElement.classList.remove('dark');
+			} 
+			else if (localStorage.getItem('theme') === 'dark') 
+			{
+    			document.documentElement.classList.add('dark');
+			}
 		</script>
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,7 +28,7 @@ export default {
 
 	plugins: [flowbite],
 
-	darkMode: 'class',
+	darkMode: 'media',
 
 	safelist: [
 		'w-64',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,7 +28,7 @@ export default {
 
 	plugins: [flowbite],
 
-	darkMode: 'media',
+	darkMode: 'class',
 
 	safelist: [
 		'w-64',


### PR DESCRIPTION
~changed from using default `class` to device-defined `media` for dark mode status, localStorage overrides this~